### PR TITLE
Prevent attempt at reset on connect

### DIFF
--- a/src/webserial.js
+++ b/src/webserial.js
@@ -64,9 +64,9 @@ async function transceive(data, add_newlines=true) {
 
 async function reset() {
     // Toggle badge reset pin
-    await port.setSignals({ requestToSend: true, dataTerminalReady: false });
-    await sleep(100);
-    await port.setSignals({ requestToSend: false, dataTerminalReady: false });
+    //await port.setSignals({ requestToSend: true, dataTerminalReady: false });
+    //await sleep(100);
+    //await port.setSignals({ requestToSend: false, dataTerminalReady: false });
     
     // Wait for the firmware to start
     await sleep(1000);


### PR DESCRIPTION
Soft-resetting the badge makes sense when dealing with non-native USB, but as we are connected over an CDC-ACM tty that's instantiated after ESP boot, we cannot reset without losing the port. In fact, the TiDAL does not implement the reset hint over USB DTS/RTS lines, so all this does is disable the port with flow control.