### PR TITLE
Add atomic transceive and use for commands

### DIFF
--- a/src/webserial.js
+++ b/src/webserial.js
@@ -121,6 +121,8 @@ export async function fetch_dir(dir_name) {
     let lines = answer.trimEnd().split('\n');
     let result = [dir_name !== '' ? dir_name : '/'];
 
+    // Cut off space remaining
+    lines = lines.slice(0, -1)
     for (let line of lines) {
         line = line.trim();
         if (line === '') {


### PR DESCRIPTION
The normal transceive operation can be a bit flakey, as it may not have all data ready in a single batch, which can cause operations to process part of the output stream from their predecessor. This adds a wrapper around transceive that fixes this by defining a known bracket around the data, as well as making use of paste mode to ensure that one command running doesn't overlap with the output of the previous if run in rapid succession.