### PR TITLE
Don't show incorrect hatchery URL on Apps screen

### DIFF
--- a/src/components/Apps.vue
+++ b/src/components/Apps.vue
@@ -366,7 +366,7 @@
                     return badges[component.repo_name]['hatchery_url'];
                 }
 
-                return badges['generic']['hatchery_url'];
+                return badges['tidal']['hatchery_url'];
             },
         }
     }


### PR DESCRIPTION
For some reason `repo_name` only gets set to `tidal` the first time the Apps component is shown and is `''` subsequently. As a result the `generic` badge config is chosen and the user ends up seeing a misleading "Apps uploaded to hatchery.badge.team will automatically show up here for everyone." message.

I don't know Vue well enough to fix this properly so figured defaulting to `tidal` config would be OK for the duration of the event :)